### PR TITLE
Add sales report transaction metrics

### DIFF
--- a/app.js
+++ b/app.js
@@ -73,6 +73,8 @@ const salesReportNetOmzet = document.getElementById('salesReportNetOmzet');
 const salesReportReturnRatio = document.getElementById('salesReportReturnRatio');
 const salesReportUniqueCustomers = document.getElementById('salesReportUniqueCustomers');
 const salesReportRepeatCustomers = document.getElementById('salesReportRepeatCustomers');
+const salesReportTotalTransactions = document.getElementById('salesReportTotalTransactions');
+const salesReportAvgOrderValue = document.getElementById('salesReportAvgOrderValue');
 const salesReportTopHostTable = document.getElementById('salesReportTopHostTable');
 const salesReportHostCombinedTable = document.getElementById('salesReportHostCombinedTable');
 const salesReportAdminCombinedTable = document.getElementById('salesReportAdminCombinedTable');
@@ -631,6 +633,11 @@ function applySalesReportFilters() {
         const totalOmzetReturn = returnData.reduce((s, r) => s + parseCurrency(r['Total Omzet'] || 0), 0);
         salesReportNetOmzet.textContent = formatCurrency(totalOmzetPenjualan - totalOmzetReturn);
         salesReportReturnRatio.textContent = `${(totalOmzetPenjualan > 0 ? (totalOmzetReturn / totalOmzetPenjualan) * 100 : 0).toFixed(2)}%`;
+
+        const totalTransactions = penjualanData.length;
+        const avgOrderValue = totalTransactions > 0 ? totalOmzetPenjualan / totalTransactions : 0;
+        salesReportTotalTransactions.textContent = totalTransactions.toLocaleString('id-ID');
+        salesReportAvgOrderValue.textContent = formatCurrency(avgOrderValue);
 
         const customerPurchaseCounts = penjualanData.reduce((acc, row) => {
             const customerName = String(row['Nama Customer'] || '').trim();

--- a/index.html
+++ b/index.html
@@ -354,6 +354,14 @@
                             <p class="text-sm text-gray-500">Total Customer Repeat</p>
                             <p id="salesReportRepeatCustomers" class="text-2xl font-bold text-green-600">0</p>
                         </div>
+                        <div class="stat-card">
+                            <p class="text-sm text-gray-500">Total Transaksi Penjualan</p>
+                            <p id="salesReportTotalTransactions" class="text-2xl font-bold text-gray-900">0</p>
+                        </div>
+                        <div class="stat-card">
+                            <p class="text-sm text-gray-500">Average Order Value</p>
+                            <p id="salesReportAvgOrderValue" class="text-2xl font-bold text-blue-600">Rp 0</p>
+                        </div>
                     </div>
 
                     <div class="space-y-8 mb-6">


### PR DESCRIPTION
## Summary
- Display total transactions and average order value on the Sales Report page
- Compute metrics in `applySalesReportFilters` and reset to zero when filtered data is empty

## Testing
- `node --check app.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896429943c0832996ab2f63702421d7