### PR TITLE
feat: add period comparison stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,12 +148,32 @@
                              </div>
                         </div>
 
-                         <div id="statsContainer" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4 mb-6">
-                            <div class="stat-card"><p class="text-sm text-gray-500">Total PCS Penjualan</p><p id="statPcsPenjualan" class="text-2xl font-bold text-gray-900">0</p></div>
-                            <div class="stat-card"><p class="text-sm text-gray-500">Total Omzet Penjualan</p><p id="statOmzetPenjualan" class="text-2xl font-bold text-green-600">Rp 0</p></div>
-                            <div class="stat-card"><p class="text-sm text-gray-500">Total PCS Return</p><p id="statPcsReturn" class="text-2xl font-bold text-gray-900">0</p></div>
-                            <div class="stat-card"><p class="text-sm text-gray-500">Total Omzet Return</p><p id="statOmzetReturn" class="text-2xl font-bold text-red-600">Rp 0</p></div>
-                            <div class="stat-card"><p class="text-sm text-gray-500">Total PCS Treatment</p><p id="statPcsTreatment" class="text-2xl font-bold text-blue-600">0</p></div>
+                        <div id="statsContainer" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4 mb-6">
+                            <div class="stat-card">
+                                <p class="text-sm text-gray-500">Total PCS Penjualan</p>
+                                <p id="statPcsPenjualan" class="text-2xl font-bold text-gray-900">0</p>
+                                <p id="statPcsPenjualanDelta" class="text-sm"></p>
+                            </div>
+                            <div class="stat-card">
+                                <p class="text-sm text-gray-500">Total Omzet Penjualan</p>
+                                <p id="statOmzetPenjualan" class="text-2xl font-bold text-green-600">Rp 0</p>
+                                <p id="statOmzetPenjualanDelta" class="text-sm"></p>
+                            </div>
+                            <div class="stat-card">
+                                <p class="text-sm text-gray-500">Total PCS Return</p>
+                                <p id="statPcsReturn" class="text-2xl font-bold text-gray-900">0</p>
+                                <p id="statPcsReturnDelta" class="text-sm"></p>
+                            </div>
+                            <div class="stat-card">
+                                <p class="text-sm text-gray-500">Total Omzet Return</p>
+                                <p id="statOmzetReturn" class="text-2xl font-bold text-red-600">Rp 0</p>
+                                <p id="statOmzetReturnDelta" class="text-sm"></p>
+                            </div>
+                            <div class="stat-card">
+                                <p class="text-sm text-gray-500">Total PCS Treatment</p>
+                                <p id="statPcsTreatment" class="text-2xl font-bold text-blue-600">0</p>
+                                <p id="statPcsTreatmentDelta" class="text-sm"></p>
+                            </div>
                         </div>
                         
                         <div class="mt-8">

--- a/style.css
+++ b/style.css
@@ -65,3 +65,16 @@ body {
     transition: opacity 0.2s ease-in-out;
     pointer-events: none; /* Mencegah interaksi saat loading */
 }
+
+/* Delta styling */
+.delta-positive {
+    color: #16a34a; /* green-600 */
+}
+
+.delta-negative {
+    color: #dc2626; /* red-600 */
+}
+
+.delta-neutral {
+    color: #4b5563; /* gray-600 */
+}


### PR DESCRIPTION
## Summary
- show period-over-period deltas on dashboard stats
- compute current and previous totals with helper
- style delta metrics with positive/negative colors

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_6896461302748329be0c588f54dbf6ed