### PR TITLE
Add floating action button for quick transaction entry

### DIFF
--- a/app.js
+++ b/app.js
@@ -112,6 +112,9 @@ const salesReturnBackupHostContainer = document.getElementById('salesReturnBacku
 const salesReturnBackupAdminContainer = document.getElementById('salesReturnBackupAdminContainer');
 const treatmentBackupContainer = document.getElementById('treatmentBackupContainer');
 const salesReturnOmzetInput = document.getElementById('salesReturnOmzet');
+const fab = document.getElementById('fab');
+const fabMain = document.getElementById('fabMain');
+const fabOptions = document.querySelectorAll('#fabOptions .fab-option');
 
 // --- NEW LOADER ELEMENTS ---
 const dashboardLoader = document.getElementById('dashboardLoader');
@@ -204,6 +207,10 @@ function switchPage(pageId) {
     sidebarLinks.forEach(link => link.classList.toggle('active', link.dataset.page === pageId));
     if (window.innerWidth < 1024) {
         closeSidebar();
+    }
+    if (fab) {
+        fab.classList.remove('open');
+        fab.classList.toggle('hidden', pageId === 'inputTransaksiPage');
     }
     if (['dashboardPage', 'customerReportPage', 'salesReportPage'].includes(pageId)) {
         if (!isDataFetched) {
@@ -1053,7 +1060,21 @@ document.addEventListener('DOMContentLoaded', () => {
     populateDropdown(editOrangTreatmentInput, treatmentPersonList);
 
     setupUnifiedForm();
-    
+
+    fabMain.addEventListener('click', () => {
+        fab.classList.toggle('open');
+    });
+
+    fabOptions.forEach(btn => {
+        btn.addEventListener('click', () => {
+            const type = btn.dataset.type;
+            switchPage('inputTransaksiPage');
+            transactionTypeSelect.value = type;
+            transactionTypeSelect.dispatchEvent(new Event('change'));
+            fab.classList.remove('open');
+        });
+    });
+
     const litepickerOptions = {
         singleMode: false, format: 'DD MMM YY', lang: 'id-ID', numberOfMonths: 2,
         dropdowns: { minYear: 2020, maxYear: null, months: true, years: true },

--- a/index.html
+++ b/index.html
@@ -476,7 +476,17 @@
             </main>
         </div>
     </div>
-    
+
+    <!-- Floating Action Button -->
+    <div id="fab" class="hidden">
+        <div id="fabOptions">
+            <button class="fab-option" data-type="Penjualan">Penjualan</button>
+            <button class="fab-option" data-type="Return">Return</button>
+            <button class="fab-option" data-type="Treatment">Treatment</button>
+        </div>
+        <button id="fabMain" class="fab-btn">+</button>
+    </div>
+
     <!-- Memanggil Library JavaScript Eksternal -->
     <script src="https://cdn.jsdelivr.net/npm/moment/moment.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/litepicker/dist/litepicker.js"></script>

--- a/style.css
+++ b/style.css
@@ -78,3 +78,55 @@ body {
 .delta-neutral {
     color: #4b5563; /* gray-600 */
 }
+
+/* Floating Action Button */
+#fab {
+    position: fixed;
+    bottom: 1.5rem;
+    right: 1.5rem;
+    z-index: 1000;
+}
+
+#fabMain {
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background-color: #db2777; /* pink-600 */
+    color: #fff;
+    border: none;
+    cursor: pointer;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.3);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 2rem;
+    line-height: 0;
+}
+
+#fabOptions {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    margin-bottom: 0.5rem;
+}
+
+#fabOptions .fab-option {
+    margin-top: 0.5rem;
+    padding: 0.5rem 1rem;
+    border-radius: 9999px;
+    background-color: #db2777;
+    color: #fff;
+    border: none;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.3);
+    opacity: 0;
+    transform: translateY(10px);
+    pointer-events: none;
+    transition: opacity 0.3s, transform 0.3s;
+    white-space: nowrap;
+}
+
+#fab.open #fabOptions .fab-option {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+}


### PR DESCRIPTION
## Summary
- add floating action button with quick links to Penjualan, Return, and Treatment forms
- style and animate the FAB with slide-out buttons
- implement toggle and navigation logic and hide FAB on transaction page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689720824c988329aa3065cacd81eb51