### PR TITLE
Show salary trends with previous-period comparisons

### DIFF
--- a/index.html
+++ b/index.html
@@ -396,10 +396,11 @@
                                             <th class="py-2 px-3 text-left text-xs font-medium text-gray-500 uppercase">Gaji Pokok</th>
                                             <th class="py-2 px-3 text-left text-xs font-medium text-gray-500 uppercase">Bonus</th>
                                             <th class="py-2 px-3 text-left text-xs font-medium text-gray-500 uppercase">Total</th>
+                                            <th class="py-2 px-3 text-left text-xs font-medium text-gray-500 uppercase">Perubahan</th>
                                         </tr>
                                     </thead>
                                     <tbody id="salesReportHostCombinedTable" class="divide-y divide-gray-200">
-                                        <tr><td colspan="5" class="text-center py-4 text-sm text-gray-400">Tidak ada data.</td></tr>
+                                        <tr><td colspan="6" class="text-center py-4 text-sm text-gray-400">Tidak ada data.</td></tr>
                                     </tbody>
                                 </table>
                             </div>
@@ -415,10 +416,11 @@
                                             <th class="py-2 px-3 text-left text-xs font-medium text-gray-500 uppercase">Gaji Pokok</th>
                                             <th class="py-2 px-3 text-left text-xs font-medium text-gray-500 uppercase">Bonus</th>
                                             <th class="py-2 px-3 text-left text-xs font-medium text-gray-500 uppercase">Total</th>
+        <th class="py-2 px-3 text-left text-xs font-medium text-gray-500 uppercase">Perubahan</th>
                                         </tr>
                                     </thead>
                                     <tbody id="salesReportAdminCombinedTable" class="divide-y divide-gray-200">
-                                        <tr><td colspan="5" class="text-center py-4 text-sm text-gray-400">Tidak ada data.</td></tr>
+                                        <tr><td colspan="6" class="text-center py-4 text-sm text-gray-400">Tidak ada data.</td></tr>
                                     </tbody>
                                 </table>
                             </div>
@@ -432,10 +434,11 @@
                                             <th class="py-2 px-3 text-left text-xs font-medium text-gray-500 uppercase">Nama</th>
                                             <th class="py-2 px-3 text-left text-xs font-medium text-gray-500 uppercase">Hari Unik</th>
                                             <th class="py-2 px-3 text-left text-xs font-medium text-gray-500 uppercase">Gaji Pokok</th>
+                                            <th class="py-2 px-3 text-left text-xs font-medium text-gray-500 uppercase">Perubahan</th>
                                         </tr>
                                     </thead>
                                     <tbody id="salesReportTreatmentCombinedTable" class="divide-y divide-gray-200">
-                                        <tr><td colspan="3" class="text-center py-4 text-sm text-gray-400">Tidak ada data.</td></tr>
+                                        <tr><td colspan="4" class="text-center py-4 text-sm text-gray-400">Tidak ada data.</td></tr>
                                     </tbody>
                                 </table>
                             </div>


### PR DESCRIPTION
## Summary
- calculate previous-period metrics for host, admin, and treatment roles
- display per-name salary and bonus deltas with trend arrows
- add trend columns to salary estimate tables

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898185b55b4832988c2e055453a9dd6